### PR TITLE
Tweaks to build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,19 +44,18 @@ dist: clean
 
 install: all
 	@echo installing executable file to ${DESTDIR}${BINPREFIX}
-	mkdir -p ${DESTDIR}${BINPREFIX}
-	cp -f echinus ${DESTDIR}${BINPREFIX}
-	chmod 755 ${DESTDIR}${BINPREFIX}/echinus
-	@echo installing configuration file and pixmaps to ${DESTDIR}${CONFPREFIX}/echinus
-	mkdir -p ${DESTDIR}${CONFPREFIX}/echinus
-	cp echinusrc ${DESTDIR}${CONFPREFIX}/echinus
-	cp ${PIXMAPS} ${DESTDIR}${CONFPREFIX}/echinus
+	$(INSTALL) -D -m 755 echinus ${DESTDIR}${BINPREFIX}/echinus
+	@echo installing configuration file and pixmaps to ${DESTDIR}${CONFPREFIX}
+	$(INSTALL) -D -m 644 echinusrc ${DESTDIR}${CONFPREFIX}/echinusrc
+	for file in $(PIXMAPS); do \
+		$(INSTALL) -m 644 $${file} ${DESTDIR}${CONFPREFIX}/$${file} ; \
+	done ;
 	@echo installing manual page to ${DESTDIR}${MANPREFIX}/man1
-	mkdir -p ${DESTDIR}${MANPREFIX}/man1
-	sed "s/VERSION/${VERSION}/g;s|CONFDIR|${DESTDIR}${CONF}|g" < echinus.1 > ${DESTDIR}${MANPREFIX}/man1/echinus.1
-	@echo installing README to ${DESTDIR}${DOCPREFIX}/echinus
-	mkdir -p ${DESTDIR}${DOCPREFIX}/echinus
-	sed "s|CONFDIR|${CONF}|" < README > ${DESTDIR}${DOCPREFIX}/echinus/README
+	sed -i -e "s/VERSION/${VERSION}/g;s|CONFDIR|${DESTDIR}${CONF}|g" echinus.1
+	$(INSTALL) -D -m 644 echinus.1 ${DESTDIR}${MANPREFIX}/man1/echinus.1
+	@echo installing README to ${DESTDIR}${DOCPREFIX}/echinus-${VERSION}
+	sed -i -e "s|CONFDIR|${CONF}|" README
+	$(INSTALL) -D -m 644 README ${DESTDIR}${DOCPREFIX}/echinus-${VERSION}/README
 
 uninstall:
 	@echo removing executable file from ${DESTDIR}${BINPREFIX}/bin

--- a/Makefile
+++ b/Makefile
@@ -21,49 +21,49 @@ options:
 
 .c.o:
 	@echo CC $<
-	@${CC} ${CPPFLAGS} -c ${CFLAGS} $<
+	${CC} ${CPPFLAGS} -c ${CFLAGS} $<
 
 ${OBJ}: config.mk ${HEADERS}
 
 echinus: ${OBJ} ${SRC} ${HEADERS}
 	@echo CC -o $@
-	@${CC} ${CFLAGS} ${LDFLAGS} -o $@ ${OBJ} ${LIBS}
+	${CC} ${CFLAGS} ${LDFLAGS} -o $@ ${OBJ} ${LIBS}
 
 clean:
 	@echo cleaning
-	@rm -f echinus ${OBJ} echinus-${VERSION}.tar.gz *~
+	rm -f echinus ${OBJ} echinus-${VERSION}.tar.gz *~
 
 dist: clean
 	@echo creating dist tarball
-	@mkdir -p echinus-${VERSION}
-	@cp -R LICENSE Makefile README config.mk \
+	mkdir -p echinus-${VERSION}
+	cp -R LICENSE Makefile README config.mk \
 		echinus.1 echinusrc ${SRC} ${HEADERS} ${PIXMAPS} echinus-${VERSION}
-	@tar -cf echinus-${VERSION}.tar echinus-${VERSION}
-	@gzip echinus-${VERSION}.tar
-	@rm -rf echinus-${VERSION}
+	tar -cf echinus-${VERSION}.tar echinus-${VERSION}
+	gzip echinus-${VERSION}.tar
+	rm -rf echinus-${VERSION}
 
 install: all
 	@echo installing executable file to ${DESTDIR}${BINPREFIX}
-	@mkdir -p ${DESTDIR}${BINPREFIX}
-	@cp -f echinus ${DESTDIR}${BINPREFIX}
-	@chmod 755 ${DESTDIR}${BINPREFIX}/echinus
+	mkdir -p ${DESTDIR}${BINPREFIX}
+	cp -f echinus ${DESTDIR}${BINPREFIX}
+	chmod 755 ${DESTDIR}${BINPREFIX}/echinus
 	@echo installing configuration file and pixmaps to ${DESTDIR}${CONFPREFIX}/echinus
-	@mkdir -p ${DESTDIR}${CONFPREFIX}/echinus
-	@cp echinusrc ${DESTDIR}${CONFPREFIX}/echinus
-	@cp ${PIXMAPS} ${DESTDIR}${CONFPREFIX}/echinus
+	mkdir -p ${DESTDIR}${CONFPREFIX}/echinus
+	cp echinusrc ${DESTDIR}${CONFPREFIX}/echinus
+	cp ${PIXMAPS} ${DESTDIR}${CONFPREFIX}/echinus
 	@echo installing manual page to ${DESTDIR}${MANPREFIX}/man1
-	@mkdir -p ${DESTDIR}${MANPREFIX}/man1
-	@sed "s/VERSION/${VERSION}/g;s|CONFDIR|${DESTDIR}${CONF}|g" < echinus.1 > ${DESTDIR}${MANPREFIX}/man1/echinus.1
+	mkdir -p ${DESTDIR}${MANPREFIX}/man1
+	sed "s/VERSION/${VERSION}/g;s|CONFDIR|${DESTDIR}${CONF}|g" < echinus.1 > ${DESTDIR}${MANPREFIX}/man1/echinus.1
 	@echo installing README to ${DESTDIR}${DOCPREFIX}/echinus
-	@mkdir -p ${DESTDIR}${DOCPREFIX}/echinus
-	@sed "s|CONFDIR|${CONF}|" < README > ${DESTDIR}${DOCPREFIX}/echinus/README
+	mkdir -p ${DESTDIR}${DOCPREFIX}/echinus
+	sed "s|CONFDIR|${CONF}|" < README > ${DESTDIR}${DOCPREFIX}/echinus/README
 
 uninstall:
 	@echo removing executable file from ${DESTDIR}${BINPREFIX}/bin
-	@rm -f ${DESTDIR}${BINPREFIX}/bin/echinus
-	@echo removing manual page from ${DESTDIR}${MANPREFIX}/man1
-	@rm -f ${DESTDIR}${MANPREFIX}/man1/echinus.1
-	@echo removing configuration file and pixmaps from ${DESTDIR}${CONFPREFIX}
-	@rm -rf ${DESTDIR}${CONFPREFIX}
+	rm -f ${DESTDIR}${BINPREFIX}/bin/echinus
+	echo removing manual page from ${DESTDIR}${MANPREFIX}/man1
+	rm -f ${DESTDIR}${MANPREFIX}/man1/echinus.1
+	echo removing configuration file and pixmaps from ${DESTDIR}${CONFPREFIX}
+	rm -rf ${DESTDIR}${CONFPREFIX}
 
 .PHONY: all options clean dist install uninstall

--- a/Makefile
+++ b/Makefile
@@ -13,19 +13,21 @@ all: options echinus ${HEADERS}
 
 options:
 	@echo echinus build options:
+	@echo "CPPFLAGS = ${CPPFLAGS}"
 	@echo "CFLAGS   = ${CFLAGS}"
 	@echo "LDFLAGS  = ${LDFLAGS}"
+	@echo "LIBS     = ${LIBS}"
 	@echo "CC       = ${CC}"
 
 .c.o:
 	@echo CC $<
-	@${CC} -c ${CFLAGS} $<
+	@${CC} ${CPPFLAGS} -c ${CFLAGS} $<
 
 ${OBJ}: config.mk ${HEADERS}
 
 echinus: ${OBJ} ${SRC} ${HEADERS}
 	@echo CC -o $@
-	@${CC} -o $@ ${OBJ} ${LDFLAGS}
+	@${CC} ${CFLAGS} ${LDFLAGS} -o $@ ${OBJ} ${LIBS}
 
 clean:
 	@echo cleaning

--- a/README
+++ b/README
@@ -12,9 +12,9 @@ echinus wm.
 
 You need X11 and Xft headers to compile echinus wm and the pkg-config tool.
 Packages containing this stuff are probably named libx11-dev and libxft-dev
-(note "-dev" suffix). You need libxrandr for multihead support (can be 
-disabled in config.mk if not needed). XRandr-enabled binary still works
-with single monitor configurations.
+(note "-dev" suffix). You need libxrandr for multihead support (disabled by 
+default, pass MULTIHEAD=1 to make in order to enable it). XRandr-enabled 
+binary still works with single monitor configurations.
 
 # make
 # make install

--- a/config.mk
+++ b/config.mk
@@ -15,8 +15,8 @@ X11INC?= /usr/X11R6/include
 X11LIB?= /usr/X11R6/lib
 
 # includes and libs
-INCS = -I. -I/usr/include -I${X11INC} `pkg-config --cflags xft`
-LIBS = -L/usr/lib -lc -L${X11LIB} -lX11 `pkg-config --libs xft`
+INCS = -I. -I${X11INC} `pkg-config --cflags xft`
+LIBS = -L${X11LIB} -lX11 `pkg-config --libs xft`
 
 DEFS = -DVERSION=\"${VERSION}\" -DSYSCONFPATH=\"${CONF}\"
 

--- a/config.mk
+++ b/config.mk
@@ -2,12 +2,13 @@
 VERSION = 0.4.9
 
 # Customize below to fit your system
+INSTALL?=/usr/bin/install
 
 # paths
 PREFIX?= /usr/local
 BINPREFIX?= ${PREFIX}/bin
 MANPREFIX?= ${PREFIX}/share/man
-CONFPREFIX?= ${PREFIX}/share/examples
+CONFPREFIX?= ${PREFIX}/share/echinus
 DOCPREFIX?= ${PREFIX}/share/doc
 CONF?= ${CONFPREFIX}
 

--- a/config.mk
+++ b/config.mk
@@ -11,12 +11,9 @@ CONFPREFIX?= ${PREFIX}/share/examples
 DOCPREFIX?= ${PREFIX}/share/doc
 CONF?= ${CONFPREFIX}
 
-X11INC?= /usr/X11R6/include
-X11LIB?= /usr/X11R6/lib
-
 # includes and libs
-INCS = -I. -I${X11INC} `pkg-config --cflags xft`
-LIBS = -L${X11LIB} -lX11 `pkg-config --libs xft`
+INCS = -I. `pkg-config --cflags x11 xft`
+LIBS = `pkg-config --libs x11 xft`
 
 DEFS = -DVERSION=\"${VERSION}\" -DSYSCONFPATH=\"${CONF}\"
 

--- a/config.mk
+++ b/config.mk
@@ -12,28 +12,28 @@ DOCPREFIX?= ${PREFIX}/share/doc
 CONF?= ${CONFPREFIX}
 
 # includes and libs
-INCS = -I. `pkg-config --cflags x11 xft`
-LIBS = `pkg-config --libs x11 xft`
+CFLAGS += -I. `pkg-config --cflags x11 xft`
+LIBS += `pkg-config --libs x11 xft`
+CPPFLAGS += -DVERSION=\"${VERSION}\" -DSYSCONFPATH=\"${CONF}\"
 
-DEFS = -DVERSION=\"${VERSION}\" -DSYSCONFPATH=\"${CONF}\"
-
-# flags
-CFLAGS = -Os ${INCS} ${DEFS}
-LDFLAGS = -s ${LIBS}
 # debug flags
-CFLAGS = -g3 -ggdb3 -std=c99 -pedantic -O0 ${INCS} -DDEBUG ${DEFS}
-LDFLAGS = -g3 -ggdb3 ${LIBS}
-
+ifdef DEBUG
+CFLAGS += -g3 -ggdb3 -std=c99 -pedantic -O0 ${INCS} -DDEBUG ${DEFS}
+LDFLAGS += -g3 -ggdb3
 # DEBUG: Show warnings (if any). Comment out to disable.
 #CFLAGS += -Wall -Wpadded
 # mostly useless warnings
 #CFLAGS += -W -Wcast-qual -Wshadow -Wwrite-strings
 #CFLAGS += -Werror        # Treat warnings as errors.
 #CFLAGS += -save-temps    # Keep precompiler output (great for debugging).
+endif
 
 # XRandr (multihead support). Comment out to disable.
-CFLAGS += -DXRANDR=1
-LIBS += -lXrandr
+ifdef MULTIHEAD
+CPPFLAGS += -DXRANDR=1
+LIBS += $(shell pkg-config --libs xrandr)
+CFLAGS += $(shell pkg-config --cflags xrandr)
+endif
 
 # Solaris
 #CFLAGS = -fast ${INCS} -DVERSION=\"${VERSION}\"


### PR DESCRIPTION
Summary of changes:
- respect user flags i.e. CC, {C,LD,CPP}FLAGS
- sort flags so that they're passed in standard way, i.e. defines -> CPPFLAGS, -L -l -> LIBS
- fix linking order [1]
- use 'install' instead of combination of cp,mkdir
- make xrandr an optional dependency that can be chosen during build via MULTIHEAD=1
- disable silent rules during build and install phases (that gives meaningful logs when user submit bugs), previous behaviour can be enables by passing -s to make
- don't strip binaries by default
- set default install paths to LHS standard

[1] http://www.gentoo.org/proj/en/qa/asneeded.xml
